### PR TITLE
Add .dr-open class and JS to add it to root element.

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -515,6 +515,7 @@
       .slideDown(200);
     $('.dr-input', this.element).addClass('active');
     $(selected).addClass('active').focus();
+    $(this.element).addClass('dr-open');
 
     this.calIsOpen = true;
   }
@@ -537,6 +538,7 @@
     }
 
     $('.dr-input, .dr-date', this.element).removeClass('active');
+    $(this.element).removeClass('dr-open');
 
     this.calIsOpen = false;
   }

--- a/dev/sass/_daterange.scss
+++ b/dev/sass/_daterange.scss
@@ -94,6 +94,9 @@
     }
   }
 
+  &.dr-open {
+    z-index: 10;
+  }
 
   .dr-selections {
     position: absolute;
@@ -298,5 +301,5 @@
         text-align: left;
       }
     }
-  } 
+  }
 }


### PR DESCRIPTION
Because all the root `.daterange` elements have the same z-index, you can run into stacking issues if you have a bunch of datepickers close to each other.

This adds a `.dr-open` class and adds/removes it when the calendar is open so it displays above other date pickers.
