### PR TITLE
Display formats & i18n

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -110,7 +110,7 @@
 
             var back = moment(self.current_date).subtract(1, timeframe);
 
-            $(this).html(back.format(this.display_format));
+            $(this).html(back.format(self.display_format));
             self.current_date = back._d;
           break;
 
@@ -126,7 +126,7 @@
 
             var forward = moment(self.current_date).add(1, timeframe);
 
-            $(this).html(forward.format(this.display_format));
+            $(this).html(forward.format(self.display_format));
             self.current_date = forward._d;
           break;
         }

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -34,7 +34,7 @@
     this.same_day =       settings.same_day || false;
 
     // These display formats denote the format for the visualisation
-    this.display_format = settings.display_format || 'D MMMM [x] YYYY';
+    this.display_format = settings.display_format || 'MMMM D, YYYY';
     this.display_year_format = settings.display_year_format || 'YYYY';
     this.display_month_format = settings.display_month_format || 'MMMM';
 

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
-  
+
   <title>Baremetrics Date Range Picker</title>
 
   <link rel="stylesheet" href="css/application.css" />
@@ -15,7 +15,7 @@
   <div class="daterange daterange--double"></div>
   <div class="daterange daterange--single"></div>
 
-  <script src="js/Calendar.js"></script>
+  <script src="../dev/js/Calendar.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
# Display formats and localization

Fixes #2 except for the presets. I will tackle that in a different branch, because the presets should be complete rewritten.

It now supports ANY display format for the date, a transform function for the day, month and year displays, a format for the month and year switchers and automagically uses moment's locale.
## Locale

Set `moment.locale( ... )` to instantly localize the entire picker for a locale, except for the display date. Follow instructions on [momentjs.com](http://momentjs.com) how to include a locale file.
## Display format options
- Use `display_format = moment_format` for display dates. 
  - Accepts any format, such as `D [x]  MMMM [x] YY`.
  - Default is `MMMM D, YYYY`
  - Consider changing default to the localized variant `LL`
- Use `display_month_format = moment_format` for displayed month names (switcher).
  - Accepts `MMMM` and `MM`
  - Default is `MMMM`
- Use `display_year_format = moment_format` for displayed year names (switcher). 
  - Accepts `YYYY` and `YY`
  - Default is `YYYY`

The date parser that accepts `now`, `stringToDate` etc. now also parses using the set `display_format`.
## Transformation functions

Right before a day name, month name or year number is displayed in the switchers or the table header, it is ran through a tranformation function
- Use `transform_day = function(d){ return d; }` to transform the day display right before it's displayed. 
  - Defaults to a function that trims the string to a single character
  - No trimming (2 characters) actually looks great. 
  - Use `moment.weekDaysMin()` to match the value with the day.
  - Consider accepting an array of week days etc. to display instead
- Use `transform_month` for the month switcher
- Use `transform_year` for the year switcher

The month/year values of the switchers are stored into data variables (because with the transform functions, you could irreversibly transform the string).
