### PR TITLE
Add required flag to be set on double calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ new Calendar({
       end: moment().subtract(1, 'month').endOf('month')
     }]
   ```
+- **required** `[boolean]`
+  - Toggle if this field must have always have a valid selected dates
 
 ### Single Calendar Params
 - **current_date** `[date]`
   - The date to start the calendar on
-- **required** `[boolean]`
-  - Toggle if this field must have always have a valid selected date
 - **placeholder** `[string]`
   - Set placeholder text (note this will only apply if the required key is set to `false`). The default will be whatever moment date format you're using. (i.e. 'M/D/YYYY')
 
@@ -106,6 +106,10 @@ new Calendar({
   - The double calendar adds the `preset` key to the format object for formatting the preset dates in the preset dropdown
 - **same_day_range** `[boolean]`
   - Allow a range selection of a single day
+- **placeholder_start** `[string]`
+  - Set placeholder text for the start date (note this will only apply if the required key is set to `false`). The default will be whatever moment date format you're using. (i.e. 'M/D/YYYY')
+- **placeholder_end** `[string]`
+  - Set placeholder text for the end date (note this will only apply if the required key is set to `false`). The default will be whatever moment date format you're using. (i.e. 'M/D/YYYY')
 
 ---
 

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -33,10 +33,12 @@
     this.format.jump_month =  settings.format && settings.format.jump_month || 'MMMM';
     this.format.jump_year =   settings.format && settings.format.jump_year || 'YYYY';
 
-    this.placeholder =    settings.placeholder || this.format.input;
+    this.placeholder =        settings.placeholder || this.format.input;
+    this.placeholder_start =  settings.placeholder_start || this.format.input;
+    this.placeholder_end =    settings.placeholder_end  || this.format.input;
 
-    this.days_array =     settings.days_array && settings.days_array.length == 7 ? 
-                          settings.days_array : 
+    this.days_array =     settings.days_array && settings.days_array.length == 7 ?
+                          settings.days_array :
                           ['S','M','T','W','T','F','S'];
 
     this.orig_start_date =    null;
@@ -188,7 +190,7 @@
     this.element.on('click', function() {
       $('.daterange, input').add(window).on('click', function(f) {
         var contains = self.element.find(f.target);
-        
+
         if (!contains.length) {
           if (self.presetIsOpen)
             self.presetToggle();
@@ -231,7 +233,7 @@
   Calendar.prototype.presetCreate = function() {
     var self = this;
     var ul_presets = $('<ul class="dr-preset-list" style="display: none;"></ul>');
-    var presets = typeof self.settings.presets == 'object' ? self.settings.presets : 
+    var presets = typeof self.settings.presets == 'object' ? self.settings.presets :
     [{
       label: 'Last 30 days',
       start: moment(this.latest_date).subtract(29, 'days'),
@@ -293,8 +295,26 @@
 
 
   Calendar.prototype.calendarSetDates = function() {
-    $('.dr-date-start', this.element).html(moment(this.start_date).format(this.format.input));
-    $('.dr-date-end', this.element).html(moment(this.end_date).format(this.format.input));
+
+    if (this.start_date) {
+      var old_start_date = $('.dr-date-start', this.element).html();
+      var new_start_date = moment(this.start_date).format(this.format.input);
+      if (old_start_date.length == 0 && !this.required)
+        new_start_date = '';
+
+      if (old_start_date != new_start_date)
+        $('.dr-date-start', this.element).html(new_start_date);
+    }
+
+    if (this.end_date) {
+      var old_end_date = $('.dr-date-end', this.element).html();
+      var new_end_date = moment(this.end_date).format(this.format.input);
+      if (old_end_date.length == 0 && !this.required)
+        new_end_date = '';
+
+      if (old_end_date != new_end_date)
+        $('.dr-date-start', this.element).html(new_end_date);
+    }
 
     if (!this.start_date && !this.end_date) {
       var old_date = $('.dr-date', this.element).html();
@@ -398,7 +418,25 @@
     // Push and save if it's valid otherwise return to previous state
     this.start_date = s == 'Invalid Date' ? this.start_date : s;
     this.end_date = e == 'Invalid Date' ? this.end_date : e;
-    this.current_date = c == 'Invalid Date' ? this.current_date : c;
+
+    // We need to handle double inputs differently to take care of required:false scenario
+    if (c == 'Invalid Date') {
+      if ($(this.selected).hasClass('dr-date-start')) {
+        this.current_date = this.start_date;
+      }
+
+      else if ($(this.selected).hasClass('dr-date-end')) {
+        this.current_date = this.end_date;
+      }
+
+      else {
+        this.current_date = this.current_date;
+      }
+    }
+
+    else {
+      this.current_date = c;
+    }
   }
 
 
@@ -733,15 +771,15 @@
     var days = this.days_array.splice(moment().localeData().firstDayOfWeek()).concat(this.days_array.splice(0, moment().localeData().firstDayOfWeek()));
 
     $.each(days, function(i, elem) {
-      ul_days_of_the_week.append('<li class="dr-day-of-week">' + elem + '</li>'); 
+      ul_days_of_the_week.append('<li class="dr-day-of-week">' + elem + '</li>');
     });
 
     if (type == "double")
       return this.element.append('<div class="dr-input">' +
         '<div class="dr-dates">' +
-          '<div class="dr-date dr-date-start" contenteditable>'+ moment(this.start_date).format(this.format.input) +'</div>' +
+          '<div class="dr-date dr-date-start" contenteditable placeholder="'+ this.placeholder_start +'">'+ (this.required ? moment(this.start_date).format(this.format.input) : '') +'</div>' +
           '<span class="dr-dates-dash">&ndash;</span>' +
-          '<div class="dr-date dr-date-end" contenteditable>'+ moment(this.end_date).format(this.format.input) +'</div>' +
+          '<div class="dr-date dr-date-end" contenteditable placeholder="'+ this.placeholder_end +'">'+ (this.required ? moment(this.end_date).format(this.format.input) : '') +'</div>' +
         '</div>' +
 
         (this.presets ? '<div class="dr-presets">' +

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -5,7 +5,7 @@ var ss = new Calendar({
   placeholder: 'Select a Date',
   required: false
 });
-  
+
 var dd = new Calendar({
   element: $('.one'),
   earliest_date: 'January 1, 2000',
@@ -15,7 +15,7 @@ var dd = new Calendar({
   callback: function() {
     var start = moment(this.start_date).format('ll'),
         end = moment(this.end_date).format('ll');
-    
+
     console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
   }
 });
@@ -30,7 +30,7 @@ new Calendar({
   callback: function() {
     var start = moment(this.start_date).format('ll'),
         end = moment(this.end_date).format('ll');
-    
+
     console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
   }
 });
@@ -41,6 +41,9 @@ new Calendar({
   latest_date: moment(),
   start_date: moment().subtract(29, 'days'),
   end_date: moment(),
+  required: false,
+  placeholder_start: 'Select Start Date',
+  placeholder_end: 'Select End Date',
   presets: [{
     label: 'Last 30 days',
     start: moment().subtract(29, 'days'),
@@ -57,7 +60,7 @@ new Calendar({
   callback: function() {
     var start = moment(this.start_date).format('ll'),
         end = moment(this.end_date).format('ll');
-    
+
     console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
   }
 });

--- a/public/js/Calendar.js
+++ b/public/js/Calendar.js
@@ -33,10 +33,12 @@
     this.format.jump_month =  settings.format && settings.format.jump_month || 'MMMM';
     this.format.jump_year =   settings.format && settings.format.jump_year || 'YYYY';
 
-    this.placeholder =    settings.placeholder || this.format.input;
+    this.placeholder =        settings.placeholder || this.format.input;
+    this.placeholder_start =  settings.placeholder_start || this.format.input;
+    this.placeholder_end =    settings.placeholder_end  || this.format.input;
 
-    this.days_array =     settings.days_array && settings.days_array.length == 7 ? 
-                          settings.days_array : 
+    this.days_array =     settings.days_array && settings.days_array.length == 7 ?
+                          settings.days_array :
                           ['S','M','T','W','T','F','S'];
 
     this.orig_start_date =    null;
@@ -188,7 +190,7 @@
     this.element.on('click', function() {
       $('.daterange, input').add(window).on('click', function(f) {
         var contains = self.element.find(f.target);
-        
+
         if (!contains.length) {
           if (self.presetIsOpen)
             self.presetToggle();
@@ -231,7 +233,7 @@
   Calendar.prototype.presetCreate = function() {
     var self = this;
     var ul_presets = $('<ul class="dr-preset-list" style="display: none;"></ul>');
-    var presets = typeof self.settings.presets == 'object' ? self.settings.presets : 
+    var presets = typeof self.settings.presets == 'object' ? self.settings.presets :
     [{
       label: 'Last 30 days',
       start: moment(this.latest_date).subtract(29, 'days'),
@@ -293,8 +295,26 @@
 
 
   Calendar.prototype.calendarSetDates = function() {
-    $('.dr-date-start', this.element).html(moment(this.start_date).format(this.format.input));
-    $('.dr-date-end', this.element).html(moment(this.end_date).format(this.format.input));
+
+    if (this.start_date) {
+      var old_start_date = $('.dr-date-start', this.element).html();
+      var new_start_date = moment(this.start_date).format(this.format.input);
+      if (old_start_date.length == 0 && !this.required)
+        new_start_date = '';
+
+      if (old_start_date != new_start_date)
+        $('.dr-date-start', this.element).html(new_start_date);
+    }
+
+    if (this.end_date) {
+      var old_end_date = $('.dr-date-end', this.element).html();
+      var new_end_date = moment(this.end_date).format(this.format.input);
+      if (old_end_date.length == 0 && !this.required)
+        new_end_date = '';
+
+      if (old_end_date != new_end_date)
+        $('.dr-date-start', this.element).html(new_end_date);
+    }
 
     if (!this.start_date && !this.end_date) {
       var old_date = $('.dr-date', this.element).html();
@@ -398,7 +418,25 @@
     // Push and save if it's valid otherwise return to previous state
     this.start_date = s == 'Invalid Date' ? this.start_date : s;
     this.end_date = e == 'Invalid Date' ? this.end_date : e;
-    this.current_date = c == 'Invalid Date' ? this.current_date : c;
+
+    // We need to handle double inputs differently to take care of required:false scenario
+    if (c == 'Invalid Date') {
+      if ($(this.selected).hasClass('dr-date-start')) {
+        this.current_date = this.start_date;
+      }
+
+      else if ($(this.selected).hasClass('dr-date-end')) {
+        this.current_date = this.end_date;
+      }
+
+      else {
+        this.current_date = this.current_date;
+      }
+    }
+
+    else {
+      this.current_date = c;
+    }
   }
 
 
@@ -733,15 +771,15 @@
     var days = this.days_array.splice(moment().localeData().firstDayOfWeek()).concat(this.days_array.splice(0, moment().localeData().firstDayOfWeek()));
 
     $.each(days, function(i, elem) {
-      ul_days_of_the_week.append('<li class="dr-day-of-week">' + elem + '</li>'); 
+      ul_days_of_the_week.append('<li class="dr-day-of-week">' + elem + '</li>');
     });
 
     if (type == "double")
       return this.element.append('<div class="dr-input">' +
         '<div class="dr-dates">' +
-          '<div class="dr-date dr-date-start" contenteditable>'+ moment(this.start_date).format(this.format.input) +'</div>' +
+          '<div class="dr-date dr-date-start" contenteditable placeholder="'+ this.placeholder_start +'">'+ (this.required ? moment(this.start_date).format(this.format.input) : '') +'</div>' +
           '<span class="dr-dates-dash">&ndash;</span>' +
-          '<div class="dr-date dr-date-end" contenteditable>'+ moment(this.end_date).format(this.format.input) +'</div>' +
+          '<div class="dr-date dr-date-end" contenteditable placeholder="'+ this.placeholder_end +'">'+ (this.required ? moment(this.end_date).format(this.format.input) : '') +'</div>' +
         '</div>' +
 
         (this.presets ? '<div class="dr-presets">' +

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -5,7 +5,7 @@ var ss = new Calendar({
   placeholder: 'Select a Date',
   required: false
 });
-  
+
 var dd = new Calendar({
   element: $('.one'),
   earliest_date: 'January 1, 2000',
@@ -15,7 +15,7 @@ var dd = new Calendar({
   callback: function() {
     var start = moment(this.start_date).format('ll'),
         end = moment(this.end_date).format('ll');
-    
+
     console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
   }
 });
@@ -30,7 +30,7 @@ new Calendar({
   callback: function() {
     var start = moment(this.start_date).format('ll'),
         end = moment(this.end_date).format('ll');
-    
+
     console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
   }
 });
@@ -41,6 +41,9 @@ new Calendar({
   latest_date: moment(),
   start_date: moment().subtract(29, 'days'),
   end_date: moment(),
+  required: false,
+  placeholder_start: 'Select Start Date',
+  placeholder_end: 'Select End Date',
   presets: [{
     label: 'Last 30 days',
     start: moment().subtract(29, 'days'),
@@ -57,7 +60,7 @@ new Calendar({
   callback: function() {
     var start = moment(this.start_date).format('ll'),
         end = moment(this.end_date).format('ll');
-    
+
     console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
   }
 });


### PR DESCRIPTION
Allow a double calendar to not be required. This lets you start with a
blank double and show placeholders in each input. It also allows you to
clear out the dates if desired.
- Move required param up to the base calendar section
- Add two new params in the double calendar section `placeholder_start`
  and `placeholder_end`
