### PR TITLE
Fix for #51, should use locale day of week format

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -645,8 +645,8 @@
 
     var first_day = moment(switcher || current).startOf('month');
     var last_day = moment(switcher || current).endOf('month');
-    var current_month_start_day = +first_day.format('d') - moment().localeData().firstDayOfWeek();
-    var current_month_end_day = +last_day.format('d') - moment().localeData().firstDayOfWeek();
+    var current_month_start_day = +first_day.format('e') - moment().localeData().firstDayOfWeek();
+    var current_month_end_day = +last_day.format('e') - moment().localeData().firstDayOfWeek();
 
     var current_month = {
       start: {


### PR DESCRIPTION
Fix for #51

The format should be the `locale` day of week, since the operation is done on `moment().localeData()`.

As provided by moment.js documentations:
http://momentjs.com/docs/#/displaying/format/
