### PR TITLE
Added compatibility with Moment Timezone.

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -356,7 +356,7 @@
 
     // Convert using settings format
     if (d && $.type(d) == 'string') {
-      var parsed_d = moment(d, this.format.input);
+      var parsed_d = this.parseDate(d);
       if (parsed_d.isValid())
         d = parsed_d;
     }
@@ -743,6 +743,15 @@
       '</div>' +
     '</div>');
   }
+
+
+  Calendar.prototype.parseDate = function(d) {
+    if (moment.defaultZone != null && moment.hasOwnProperty('tz')) {
+      return moment.tz(d, this.format.input, moment.defaultZone.name);
+    } else {
+      return moment(d, this.format.input);
+    }
+  };
 
 
   Calendar.prototype.range = function(length) {

--- a/public/js/Calendar.js
+++ b/public/js/Calendar.js
@@ -356,7 +356,7 @@
 
     // Convert using settings format
     if (d && $.type(d) == 'string') {
-      var parsed_d = moment(d, this.format.input);
+      var parsed_d = this.parseDate(d);
       if (parsed_d.isValid())
         d = parsed_d;
     }
@@ -743,6 +743,15 @@
       '</div>' +
     '</div>');
   }
+
+
+  Calendar.prototype.parseDate = function(d) {
+    if (moment.defaultZone != null && moment.hasOwnProperty('tz')) {
+      return moment.tz(d, this.format.input, moment.defaultZone.name);
+    } else {
+      return moment(d, this.format.input);
+    }
+  };
 
 
   Calendar.prototype.range = function(length) {


### PR DESCRIPTION
This allows the use of this component with pages that use Moment Timezone and have a default timezone set. Without this fix, the component interprets the dates from the input fields as UTC, causing Calendar.checkDate to return erroneous results, which are then put back into the input fields as timezoneless dates. This causes some dates to be off by days.