### PR TITLE
Use document for outside click so that shadow roots can be used

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -185,8 +185,8 @@
 
     // Once you click into a selection.. this lets you click out
     this.element.on('click', function() {
-      window.addEventListener('click', function (f) {
-        var contains = self.element.find(f.target);
+      document.addEventListener('click', function (f) {
+        var contains = self.element.find(f.path[0]);
 
         if (!contains.length) {
           if (self.presetIsOpen)

--- a/public/js/Calendar.js
+++ b/public/js/Calendar.js
@@ -185,8 +185,8 @@
 
     // Once you click into a selection.. this lets you click out
     this.element.on('click', function() {
-      window.addEventListener('click', function (f) {
-        var contains = self.element.find(f.target);
+      document.addEventListener('click', function (f) {
+        var contains = self.element.find(f.path[0]);
 
         if (!contains.length) {
           if (self.presetIsOpen)


### PR DESCRIPTION
The click handler for outside click is relying on window which breaks when using a shadowdom/shadowroot. By using document and path both the shadowdom case and the standard case work for outside click detection.