### PR TITLE
Stop confusing momentjs's constructor

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -44,9 +44,9 @@
     this.orig_current_date =  null;
 
     this.earliest_date =  settings.earliest_date ? moment(settings.earliest_date)
-                          : moment('1900-01-01');
+                          : moment('1900-01-01', 'YYYY-MM-DD');
     this.latest_date =    settings.latest_date ? moment(settings.latest_date)
-                          : moment('2900-12-31');
+                          : moment('2900-12-31', 'YYYY-MM-DD');
     this.end_date =       settings.end_date ? moment(settings.end_date)
                           : (this.type == 'double' ? moment() : null);
     this.start_date =     settings.start_date ? moment(settings.start_date)


### PR DESCRIPTION
When momentjs's constructor is used to parse a date string that is not in RFC2822 or ISO format, it logs this warning to the console:
> Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.

In this PR, I am setting the format of the earliest and latest date fallback values.