### PR TITLE
Remove daterange class from event

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -186,8 +186,11 @@
 
     // Once you click into a selection.. this lets you click out
     this.element.on('click', function() {
+      var this_element = this;
+
       document.addEventListener('click', function (event) {
-        var contains = $(event.target).parents('.daterange');
+        // Detect if the target of the click is child of the calendar
+        var contains = $(event.target).parents('.' + this_element.classList[0]);
 
         if (!contains.length) {
           if (self.presetIsOpen)

--- a/public/js/Calendar.js
+++ b/public/js/Calendar.js
@@ -186,8 +186,11 @@
 
     // Once you click into a selection.. this lets you click out
     this.element.on('click', function() {
+      var this_element = this;
+
       document.addEventListener('click', function (event) {
-        var contains = $(event.target).parents('.daterange');
+        // Detect if the target of the click is child of the calendar
+        var contains = $(event.target).parents('.' + this_element.classList[0]);
 
         if (!contains.length) {
           if (self.presetIsOpen)


### PR DESCRIPTION
This is possibly related to this issue: https://github.com/Baremetrics/calendar/issues/87

We don't use `.daterange` in our classes - we use `.someprefix-daterange` and we noticed that the calendar was not being closed on Firefox. 

Reading the coding and following the tip from @gerdus I saw one `parents('.daterange')` in the code. Not sure if you have a better way to invoke the parents here but this approach works.

Edit: I can also follow the approach reported in the issues - your call

Thanks, cheers (and look at my mug :))

![img_2298](https://user-images.githubusercontent.com/13719/42789342-b116c5d6-8919-11e8-8e90-ffb90f42ef26.JPG)
