### PR TITLE
Fixes https://github.com/Baremetrics/calendar/issues/92 (close calendar on click outside)

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -187,7 +187,7 @@
     // Once you click into a selection.. this lets you click out
     this.element.on('click', function() {
       document.addEventListener('click', function (event) {
-        var contains = $(event.target).parents(self.element);
+        var contains = $(event.target).parent().closest(self.element);
 
         if (!contains.length) {
           if (self.presetIsOpen)

--- a/public/js/Calendar.js
+++ b/public/js/Calendar.js
@@ -187,7 +187,7 @@
     // Once you click into a selection.. this lets you click out
     this.element.on('click', function() {
       document.addEventListener('click', function (event) {
-        var contains = $(event.target).parents(self.element);
+        var contains = $(event.target).parent().closest(self.element);
 
         if (!contains.length) {
           if (self.presetIsOpen)


### PR DESCRIPTION
Fixes https://github.com/Baremetrics/calendar/issues/92 

Swaps out `.parents()`, which only takes a string selector (not a DOM/jQuery element as is being used in the existing code) for `.closest()`, which can take an element too.

Since `.closest()` includes own element instead of just ancestors, we require a `.parent()` call first to "step up" 1 level in the tree before traversing.