### PR TITLE
Preserve and display preset titles

### DIFF
--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -68,6 +68,7 @@
       var start = $('.dr-item-aside', this).data('start');
       var end = $('.dr-item-aside', this).data('end');
 
+      self.preset_label = $(this).data('label');
       self.start_date = self.calendarCheckDate(start);
       self.end_date = self.calendarCheckDate(end);
 
@@ -295,7 +296,7 @@
         item.data('end', endISO);
         item.html(string);
       } else {
-        ul_presets.append('<li class="dr-list-item">'+ d.label +
+        ul_presets.append('<li class="dr-list-item" data-label="' + d.label + '">'+ d.label +
           '<span class="dr-item-aside" data-start="'+ startISO +'" data-end="'+ endISO +'">'+ string +'</span>'+
         '</li>');
       }
@@ -306,8 +307,19 @@
 
 
   Calendar.prototype.calendarSetDates = function() {
+    // fill widgets with data
     $('.dr-date-start', this.element).html(moment(this.start_date).format(this.format.input));
     $('.dr-date-end', this.element).html(moment(this.end_date).format(this.format.input));
+    $('.dr-date-preset', this.element).html(this.preset_label);
+
+    // show one set (preset vs. custom days) and hide the other
+    if (this.preset_label) {
+      $('.dr-date-start, .dr-dates-dash, .dr-date-end', this.element).hide();
+      $('.dr-date-preset', this.element).show();
+    } else {
+      $('.dr-date-start, .dr-dates-dash, .dr-date-end', this.element).show();
+      $('.dr-date-preset', this.element).hide();
+    }
 
     if (!this.start_date && !this.end_date) {
       var old_date = $('.dr-date', this.element).html();
@@ -371,7 +383,11 @@
   Calendar.prototype.calendarCheckDates = function() {
     var startTxt = $('.dr-date-start', this.element).html();
     var endTxt = $('.dr-date-end', this.element).html();
-    var c = this.calendarCheckDate($(this.selected).html());
+    if (this.preset_label) {
+      var c = this.calendarCheckDate(startTxt);
+    } else {
+      var c = this.calendarCheckDate($(this.selected).html());
+    }
     var s;
     var e;
 
@@ -432,7 +448,6 @@
   Calendar.prototype.calendarOpen = function(selected, switcher) {
     var self = this;
     var other;
-    var cal_width = $('.dr-dates', this.element).innerWidth() - 8;
 
     this.selected = selected || this.selected;
 
@@ -449,6 +464,12 @@
 
     this.calendarCheckDates();
     this.calendarCreate(switcher);
+
+    if (this.preset_label) {
+        selected = this.selected = $('.dr-date.dr-date-start').get(0);
+        this.preset_label = null;
+    }
+
     this.calendarSetDates();
 
     var next_month = moment(switcher || this.current_date).add(1, 'month').startOf('month').startOf('day');
@@ -584,6 +605,7 @@
       });
     }
 
+    var cal_width = $('.dr-dates', this.element).innerWidth() - 8;
     $('.dr-calendar', this.element)
       .css('width', cal_width)
       .slideDown(200);
@@ -690,6 +712,7 @@
           '<div class="dr-date dr-date-start" contenteditable>'+ moment(this.start_date).format(this.format.input) +'</div>' +
           '<span class="dr-dates-dash">&ndash;</span>' +
           '<div class="dr-date dr-date-end" contenteditable>'+ moment(this.end_date).format(this.format.input) +'</div>' +
+          '<div class="dr-date dr-date-preset" style="display: none">' + '</div>' +
         '</div>' +
 
         (this.presets ? '<div class="dr-presets">' +

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -54,6 +54,7 @@
     this.current_date =   settings.current_date ? moment(settings.current_date)
                           : (this.type == 'single' ? moment() : null);
 
+    this.sticky_presets = settings.sticky_presets || false;
     this.presets =        settings.presets == false || this.type == 'single' ? false : true;
 
     this.callback =       settings.callback || this.calendarSetDates;
@@ -313,12 +314,14 @@
     $('.dr-date-preset', this.element).html(this.preset_label);
 
     // show one set (preset vs. custom days) and hide the other
-    if (this.preset_label) {
-      $('.dr-date-start, .dr-dates-dash, .dr-date-end', this.element).hide();
-      $('.dr-date-preset', this.element).show();
-    } else {
-      $('.dr-date-start, .dr-dates-dash, .dr-date-end', this.element).show();
-      $('.dr-date-preset', this.element).hide();
+    if (this.sticky_presets) {
+      if (this.preset_label) {
+        $('.dr-date-start, .dr-dates-dash, .dr-date-end', this.element).hide();
+        $('.dr-date-preset', this.element).show();
+      } else {
+        $('.dr-date-start, .dr-dates-dash, .dr-date-end', this.element).show();
+        $('.dr-date-preset', this.element).hide();
+      }
     }
 
     if (!this.start_date && !this.end_date) {

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -42,6 +42,7 @@
     this.orig_start_date =    null;
     this.orig_end_date =      null;
     this.orig_current_date =  null;
+    this.orig_preset_label =  null;
 
     this.earliest_date =  settings.earliest_date ? moment(settings.earliest_date)
                           : moment('1900-01-01', 'YYYY-MM-DD');
@@ -217,6 +218,7 @@
       this.orig_start_date = this.start_date;
       this.orig_end_date = this.end_date;
       this.orig_current_date = this.current_date;
+      this.orig_preset_label = this.preset_label;
 
       this.presetIsOpen = true;
     } else if (this.presetIsOpen) {
@@ -339,7 +341,7 @@
 
   Calendar.prototype.calendarSaveDates = function() {
     if (this.type === 'double') {
-      if (!moment(this.orig_end_date).isSame(this.end_date) || !moment(this.orig_start_date).isSame(this.start_date))
+      if (!moment(this.orig_end_date).isSame(this.end_date) || !moment(this.orig_start_date).isSame(this.start_date) || (this.sticky_presets && (this.orig_preset_label !== this.preset_label)))
         return this.callback();
     } else {
       if (!this.required || !moment(this.orig_current_date).isSame(this.current_date))
@@ -465,6 +467,7 @@
       this.orig_start_date = this.start_date;
       this.orig_end_date = this.end_date;
       this.orig_current_date = this.current_date;
+      this.orig_preset_label = this.preset_label;
     }
 
     this.calendarCheckDates();

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -383,11 +383,8 @@
   Calendar.prototype.calendarCheckDates = function() {
     var startTxt = $('.dr-date-start', this.element).html();
     var endTxt = $('.dr-date-end', this.element).html();
-    if (this.preset_label) {
-      var c = this.calendarCheckDate(startTxt);
-    } else {
-      var c = this.calendarCheckDate($(this.selected).html());
-    }
+
+    var c = this.calendarCheckDate($(this.selected).html());
     var s;
     var e;
 
@@ -449,7 +446,12 @@
     var self = this;
     var other;
 
-    this.selected = selected || this.selected;
+    if ($(selected).hasClass('dr-date-preset')) {
+      this.selected = $('.dr-date.dr-date-start', this.element).get(0);
+      this.preset_label = null;
+    } else {
+      this.selected = selected || this.selected;
+    }
 
     if (this.presetIsOpen == true)
       this.presetToggle();
@@ -464,12 +466,6 @@
 
     this.calendarCheckDates();
     this.calendarCreate(switcher);
-
-    if (this.preset_label) {
-        selected = this.selected = $('.dr-date.dr-date-start').get(0);
-        this.preset_label = null;
-    }
-
     this.calendarSetDates();
 
     var next_month = moment(switcher || this.current_date).add(1, 'month').startOf('month').startOf('day');
@@ -610,7 +606,7 @@
       .css('width', cal_width)
       .slideDown(200);
     $('.dr-input', this.element).addClass('dr-active');
-    $(selected).addClass('dr-active').focus();
+    $(this.selected).addClass('dr-active').focus();
     this.element.addClass('dr-active');
 
     this.calIsOpen = true;

--- a/dev/js/Calendar.js
+++ b/dev/js/Calendar.js
@@ -48,12 +48,23 @@
                           : moment('1900-01-01', 'YYYY-MM-DD');
     this.latest_date =    settings.latest_date ? moment(settings.latest_date)
                           : moment('2900-12-31', 'YYYY-MM-DD');
-    this.end_date =       settings.end_date ? moment(settings.end_date)
-                          : (this.type == 'double' ? moment() : null);
-    this.start_date =     settings.start_date ? moment(settings.start_date)
-                          : (this.type == 'double' ? this.end_date.clone().subtract(1, 'month') : null);
     this.current_date =   settings.current_date ? moment(settings.current_date)
                           : (this.type == 'single' ? moment() : null);
+    this.preset_label =   settings.preset_label ? settings.preset_label
+                          : (this.type == 'single' ? 'Last 3 months' : null);
+     if(this.preset_label) {
+	var self = this;
+        var preset = settings.presets.find(function(obj) {
+          return obj.label === self.preset_label;
+        });
+        this.start_date = preset.start;
+        this.end_date = preset.end;
+    } else {
+        this.start_date =     settings.start_date ? moment(settings.start_date)
+                          : (this.type == 'double' ? this.end_date.clone().subtract(1, 'month') : null);
+        this.end_date =       settings.end_date ? moment(settings.end_date)
+                          : (this.type == 'double' ? moment() : null);
+    }
 
     this.sticky_presets = settings.sticky_presets || false;
     this.presets =        settings.presets == false || this.type == 'single' ? false : true;
@@ -61,6 +72,7 @@
     this.callback =       settings.callback || this.calendarSetDates;
 
     this.calendarHTML(this.type);
+    this.calendarSetDates();
 
     $('.dr-presets', this.element).click(function() {
       self.presetToggle();
@@ -71,6 +83,10 @@
       var end = $('.dr-item-aside', this).data('end');
 
       self.preset_label = $(this).data('label');
+      if (self.preset_label == 'custom'){
+        self.calendarOpen($('.dr-date', this.element));
+        return;
+      }
       self.start_date = self.calendarCheckDate(start);
       self.end_date = self.calendarCheckDate(end);
 
@@ -304,7 +320,7 @@
         '</li>');
       }
     });
-
+    ul_presets.append('<li class="dr-list-item" data-label="custom">Custom</li>');
     return ul_presets;
   }
 
@@ -806,6 +822,7 @@
     if ($(cal.selected).hasClass('dr-date-start')) {
       $('.dr-date-end', cal.element).trigger('click');
     } else {
+      self.preset_label = null;
       cal.calendarSaveDates();
       cal.calendarClose('force');
     }

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -66,3 +66,32 @@ new Calendar({
     console.debug('Start Date: ' + start + '\nEnd Date: ' + end + '\nPreset: ' + preset);
   }
 });
+
+new Calendar({
+  element: $('.four'),
+  sticky_presets: true,
+  earliest_date: '2000-01-01',
+  latest_date: moment(),
+  start_date: moment().subtract(29, 'days'),
+  end_date: moment(),
+  presets: [{
+    label: 'Last 30 days',
+    start: moment().subtract(29, 'days'),
+    end: moment()
+  },{
+    label: 'Last month',
+    start: moment().subtract(1, 'month').startOf('month'),
+    end: moment().subtract(1, 'month').endOf('month')
+  },{
+    label: 'Last year',
+    start: moment().subtract(1, 'year').startOf('year'),
+    end: moment().subtract(1, 'year').endOf('year')
+  }],
+  callback: function() {
+    var start = moment(this.start_date).format('ll'),
+        end = moment(this.end_date).format('ll'),
+        preset = this.preset_label;
+
+    console.debug('Start Date: ' + start + '\nEnd Date: ' + end + '\nPreset: ' + preset);
+  }
+});

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -16,9 +16,10 @@ var dd = new Calendar({
   end_date: moment(),
   callback: function() {
     var start = moment(this.start_date).format('ll'),
-        end = moment(this.end_date).format('ll');
+        end = moment(this.end_date).format('ll'),
+        preset = this.preset_label;
 
-    console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
+    console.debug('Start Date: ' + start + '\nEnd Date: ' + end + '\nPreset: ' + preset);
   }
 });
 
@@ -31,9 +32,10 @@ new Calendar({
   presets: false,
   callback: function() {
     var start = moment(this.start_date).format('ll'),
-        end = moment(this.end_date).format('ll');
+        end = moment(this.end_date).format('ll'),
+        preset = this.preset_label;
 
-    console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
+    console.debug('Start Date: ' + start + '\nEnd Date: ' + end + '\nPreset: ' + preset);
   }
 });
 
@@ -58,8 +60,9 @@ new Calendar({
   }],
   callback: function() {
     var start = moment(this.start_date).format('ll'),
-        end = moment(this.end_date).format('ll');
+        end = moment(this.end_date).format('ll'),
+        preset = this.preset_label;
 
-    console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
+    console.debug('Start Date: ' + start + '\nEnd Date: ' + end + '\nPreset: ' + preset);
   }
 });

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,8 @@
 
   <div class="daterange daterange--double three"></div>
 
+  <div class="daterange daterange--double four"></div>
+
   <div class="daterange daterange--single"></div>
 
   <footer>

--- a/public/js/Calendar.js
+++ b/public/js/Calendar.js
@@ -48,12 +48,23 @@
                           : moment('1900-01-01', 'YYYY-MM-DD');
     this.latest_date =    settings.latest_date ? moment(settings.latest_date)
                           : moment('2900-12-31', 'YYYY-MM-DD');
-    this.end_date =       settings.end_date ? moment(settings.end_date)
-                          : (this.type == 'double' ? moment() : null);
-    this.start_date =     settings.start_date ? moment(settings.start_date)
-                          : (this.type == 'double' ? this.end_date.clone().subtract(1, 'month') : null);
     this.current_date =   settings.current_date ? moment(settings.current_date)
                           : (this.type == 'single' ? moment() : null);
+    this.preset_label =   settings.preset_label ? settings.preset_label
+                          : (this.type == 'single' ? 'Last 3 months' : null);
+     if(this.preset_label) {
+	var self = this;
+        var preset = settings.presets.find(function(obj) {
+          return obj.label === self.preset_label;
+        });
+        this.start_date = preset.start;
+        this.end_date = preset.end;
+    } else {
+        this.start_date =     settings.start_date ? moment(settings.start_date)
+                          : (this.type == 'double' ? this.end_date.clone().subtract(1, 'month') : null);
+        this.end_date =       settings.end_date ? moment(settings.end_date)
+                          : (this.type == 'double' ? moment() : null);
+    }
 
     this.sticky_presets = settings.sticky_presets || false;
     this.presets =        settings.presets == false || this.type == 'single' ? false : true;
@@ -61,6 +72,7 @@
     this.callback =       settings.callback || this.calendarSetDates;
 
     this.calendarHTML(this.type);
+    this.calendarSetDates();
 
     $('.dr-presets', this.element).click(function() {
       self.presetToggle();
@@ -71,6 +83,10 @@
       var end = $('.dr-item-aside', this).data('end');
 
       self.preset_label = $(this).data('label');
+      if (self.preset_label == 'custom'){
+        self.calendarOpen($('.dr-date', this.element));
+        return;
+      }
       self.start_date = self.calendarCheckDate(start);
       self.end_date = self.calendarCheckDate(end);
 
@@ -304,7 +320,7 @@
         '</li>');
       }
     });
-
+    ul_presets.append('<li class="dr-list-item" data-label="custom">Custom</li>');
     return ul_presets;
   }
 
@@ -806,6 +822,7 @@
     if ($(cal.selected).hasClass('dr-date-start')) {
       $('.dr-date-end', cal.element).trigger('click');
     } else {
+      self.preset_label = null;
       cal.calendarSaveDates();
       cal.calendarClose('force');
     }

--- a/public/js/Calendar.js
+++ b/public/js/Calendar.js
@@ -42,6 +42,7 @@
     this.orig_start_date =    null;
     this.orig_end_date =      null;
     this.orig_current_date =  null;
+    this.orig_preset_label =  null;
 
     this.earliest_date =  settings.earliest_date ? moment(settings.earliest_date)
                           : moment('1900-01-01', 'YYYY-MM-DD');
@@ -54,6 +55,7 @@
     this.current_date =   settings.current_date ? moment(settings.current_date)
                           : (this.type == 'single' ? moment() : null);
 
+    this.sticky_presets = settings.sticky_presets || false;
     this.presets =        settings.presets == false || this.type == 'single' ? false : true;
 
     this.callback =       settings.callback || this.calendarSetDates;
@@ -68,6 +70,7 @@
       var start = $('.dr-item-aside', this).data('start');
       var end = $('.dr-item-aside', this).data('end');
 
+      self.preset_label = $(this).data('label');
       self.start_date = self.calendarCheckDate(start);
       self.end_date = self.calendarCheckDate(end);
 
@@ -215,6 +218,7 @@
       this.orig_start_date = this.start_date;
       this.orig_end_date = this.end_date;
       this.orig_current_date = this.current_date;
+      this.orig_preset_label = this.preset_label;
 
       this.presetIsOpen = true;
     } else if (this.presetIsOpen) {
@@ -295,7 +299,7 @@
         item.data('end', endISO);
         item.html(string);
       } else {
-        ul_presets.append('<li class="dr-list-item">'+ d.label +
+        ul_presets.append('<li class="dr-list-item" data-label="' + d.label + '">'+ d.label +
           '<span class="dr-item-aside" data-start="'+ startISO +'" data-end="'+ endISO +'">'+ string +'</span>'+
         '</li>');
       }
@@ -306,8 +310,21 @@
 
 
   Calendar.prototype.calendarSetDates = function() {
+    // fill widgets with data
     $('.dr-date-start', this.element).html(moment(this.start_date).format(this.format.input));
     $('.dr-date-end', this.element).html(moment(this.end_date).format(this.format.input));
+    $('.dr-date-preset', this.element).html(this.preset_label);
+
+    // show one set (preset vs. custom days) and hide the other
+    if (this.sticky_presets) {
+      if (this.preset_label) {
+        $('.dr-date-start, .dr-dates-dash, .dr-date-end', this.element).hide();
+        $('.dr-date-preset', this.element).show();
+      } else {
+        $('.dr-date-start, .dr-dates-dash, .dr-date-end', this.element).show();
+        $('.dr-date-preset', this.element).hide();
+      }
+    }
 
     if (!this.start_date && !this.end_date) {
       var old_date = $('.dr-date', this.element).html();
@@ -324,7 +341,7 @@
 
   Calendar.prototype.calendarSaveDates = function() {
     if (this.type === 'double') {
-      if (!moment(this.orig_end_date).isSame(this.end_date) || !moment(this.orig_start_date).isSame(this.start_date))
+      if (!moment(this.orig_end_date).isSame(this.end_date) || !moment(this.orig_start_date).isSame(this.start_date) || (this.sticky_presets && (this.orig_preset_label !== this.preset_label)))
         return this.callback();
     } else {
       if (!this.required || !moment(this.orig_current_date).isSame(this.current_date))
@@ -371,6 +388,7 @@
   Calendar.prototype.calendarCheckDates = function() {
     var startTxt = $('.dr-date-start', this.element).html();
     var endTxt = $('.dr-date-end', this.element).html();
+
     var c = this.calendarCheckDate($(this.selected).html());
     var s;
     var e;
@@ -432,9 +450,13 @@
   Calendar.prototype.calendarOpen = function(selected, switcher) {
     var self = this;
     var other;
-    var cal_width = $('.dr-dates', this.element).innerWidth() - 8;
 
-    this.selected = selected || this.selected;
+    if ($(selected).hasClass('dr-date-preset')) {
+      this.selected = $('.dr-date.dr-date-start', this.element).get(0);
+      this.preset_label = null;
+    } else {
+      this.selected = selected || this.selected;
+    }
 
     if (this.presetIsOpen == true)
       this.presetToggle();
@@ -445,6 +467,7 @@
       this.orig_start_date = this.start_date;
       this.orig_end_date = this.end_date;
       this.orig_current_date = this.current_date;
+      this.orig_preset_label = this.preset_label;
     }
 
     this.calendarCheckDates();
@@ -584,11 +607,12 @@
       });
     }
 
+    var cal_width = $('.dr-dates', this.element).innerWidth() - 8;
     $('.dr-calendar', this.element)
       .css('width', cal_width)
       .slideDown(200);
     $('.dr-input', this.element).addClass('dr-active');
-    $(selected).addClass('dr-active').focus();
+    $(this.selected).addClass('dr-active').focus();
     this.element.addClass('dr-active');
 
     this.calIsOpen = true;
@@ -690,6 +714,7 @@
           '<div class="dr-date dr-date-start" contenteditable>'+ moment(this.start_date).format(this.format.input) +'</div>' +
           '<span class="dr-dates-dash">&ndash;</span>' +
           '<div class="dr-date dr-date-end" contenteditable>'+ moment(this.end_date).format(this.format.input) +'</div>' +
+          '<div class="dr-date dr-date-preset" style="display: none">' + '</div>' +
         '</div>' +
 
         (this.presets ? '<div class="dr-presets">' +

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -16,9 +16,10 @@ var dd = new Calendar({
   end_date: moment(),
   callback: function() {
     var start = moment(this.start_date).format('ll'),
-        end = moment(this.end_date).format('ll');
+        end = moment(this.end_date).format('ll'),
+        preset = this.preset_label;
 
-    console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
+    console.debug('Start Date: ' + start + '\nEnd Date: ' + end + '\nPreset: ' + preset);
   }
 });
 
@@ -31,9 +32,10 @@ new Calendar({
   presets: false,
   callback: function() {
     var start = moment(this.start_date).format('ll'),
-        end = moment(this.end_date).format('ll');
+        end = moment(this.end_date).format('ll'),
+        preset = this.preset_label;
 
-    console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
+    console.debug('Start Date: ' + start + '\nEnd Date: ' + end + '\nPreset: ' + preset);
   }
 });
 
@@ -58,8 +60,38 @@ new Calendar({
   }],
   callback: function() {
     var start = moment(this.start_date).format('ll'),
-        end = moment(this.end_date).format('ll');
+        end = moment(this.end_date).format('ll'),
+        preset = this.preset_label;
 
-    console.debug('Start Date: '+ start +'\nEnd Date: '+ end);
+    console.debug('Start Date: ' + start + '\nEnd Date: ' + end + '\nPreset: ' + preset);
+  }
+});
+
+new Calendar({
+  element: $('.four'),
+  sticky_presets: true,
+  earliest_date: '2000-01-01',
+  latest_date: moment(),
+  start_date: moment().subtract(29, 'days'),
+  end_date: moment(),
+  presets: [{
+    label: 'Last 30 days',
+    start: moment().subtract(29, 'days'),
+    end: moment()
+  },{
+    label: 'Last month',
+    start: moment().subtract(1, 'month').startOf('month'),
+    end: moment().subtract(1, 'month').endOf('month')
+  },{
+    label: 'Last year',
+    start: moment().subtract(1, 'year').startOf('year'),
+    end: moment().subtract(1, 'year').endOf('year')
+  }],
+  callback: function() {
+    var start = moment(this.start_date).format('ll'),
+        end = moment(this.end_date).format('ll'),
+        preset = this.preset_label;
+
+    console.debug('Start Date: ' + start + '\nEnd Date: ' + end + '\nPreset: ' + preset);
   }
 });


### PR DESCRIPTION
#### Motivation

We need the ability to persist the state of the datepicker across page loads. This presents a major UX problem related to presets: if the user selects a `Today` preset and then reloads the page on the next day, what’s the expected behavior?
I don’t think there’s a single ‘right’ answer, but we decided that we wanted to go with ‘constantly updating’ presets.

#### Current behavior

The current behavior of datepicker is that any preset the user selects is immediately turned into a fixed daterange. So if the user selects `This month` on Jan 31, this is converted into the interval `Jan 1 - Jan 31` and the component immediately forgets that the prefix was ever chosen. If the user reloads the “this month” view on Feb 1, they will again see the `Jan 1 - Jan 31` interval.

#### Intended behavior

What we wanted to do is two-fold: First, we wanted to have the ability to actually keep the preset around and show it to the user after they’ve selected it. And second, we wanted to be able to read from the component when the user has chosen a preset as opposed to a date range, so that we can persist the specific user choice.
To continue the aforementioned example: has the user selected `This month` from the presets, or have they selected the interval from `Jan 1` to `Jan 31`?

#### Implementation

We introduce a new element with class `dr-date-preset`, which is by default hidden, and shown _instead of_ the three `dr-date-start`, `dr-dates-dash` and `dr-date-end` elements if a preset is currently selected.

When a preset is selected, this element is shown and shows the title of the current preset. When that preset title is clicked, the title turns into the current date interval and the dropdown to choose another start and end date appears.

This new functionality has to be enabled by setting the new configuration flag `sticky_presets` to `true`, Theoretically, if you don’t set this new configuration option, the behavior of the component should be unchanged. But I leave it to the reviewers to confirm that.

The change events (`callback`), now contain a new field `preset_label` which is set to the title of the preset if a preset was chosen, and `null` if a date interval was selected.

A new component with this configuration has been added to the test page.

#### Credit

This feature branch was developed in pair programming by @serglo and @hheimbuerger. Equal credit should be given, I just happen to be the messenger.

#### Preview

![2019-05-26_20-12-38](https://user-images.githubusercontent.com/159414/58385584-c37be280-7ff2-11e9-888f-4776423afc7f.gif)
